### PR TITLE
Fix sending Slack notifications and sending email

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN addgroup -S ${NAGIOS_GROUP} && \
                         libldap mariadb-connector-c freeradius-client-dev libpq libdbi \
                         lm-sensors perl net-snmp-perl perl-net-snmp perl-crypt-x509 \
                         perl-timedate perl-libwww perl-text-glob samba-client openssh openssl \
-                        net-snmp-tools && \
+                        net-snmp-tools perl-lwp-protocol-https mailx && \
                                                 \
     : '# For x64 the binary is : gosu-amd64' && \
     : '# For arm-v6 the binary is : gosu-armel' && \


### PR DESCRIPTION
By adding perl-lwp-protocol-https and mailx to apk package list, we can send Slack notifications (needing support for https protocol) and send emails (see #39 )