### PR TITLE
Alpine 3.12 is out of support as of 2022-05-01. Multiple CVEs patched…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # https://www.docker.com/blog/docker-arm-virtual-meetup-multi-arch-with-buildx/
 
-FROM alpine:3.12 as builder-base
+FROM alpine:3.13 as builder-base
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
… by moving to 3.13.