### PR TITLE
Updating adduser options to include username

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV NAGIOS_HOME=/opt/nagios \
 
 
 RUN addgroup -S ${NAGIOS_GROUP} && \
-    adduser  -S ${NAGIOS_USER} -G ${NAGIOS_CMDGROUP} && \
+    adduser  -S ${NAGIOS_USER} -G ${NAGIOS_CMDGROUP} -g ${NAGIOS_USER} && \
     apk update && \
     apk add --no-cache git curl unzip apache2 apache2-utils rsyslog \
                         php7 php7-gd php7-cli runit parallel ssmtp \


### PR DESCRIPTION
By default, the 'nagios' user gets added with a GECOS of 'Linux User'. When email notifications are sent, they are from "Linux User <nagios@yourserver>". Updating the field to use the username field.

