### PR TITLE
Updating to Alpine v3.16 & PHP8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # https://www.docker.com/blog/docker-arm-virtual-meetup-multi-arch-with-buildx/
 
-FROM alpine:3.12 as builder-base
+FROM alpine:3.16 as builder-base
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -29,8 +29,8 @@ RUN addgroup -S ${NAGIOS_GROUP} && \
     adduser  -S ${NAGIOS_USER} -G ${NAGIOS_CMDGROUP} && \
     apk update && \
     apk add --no-cache git curl unzip apache2 apache2-utils rsyslog \
-                        php7 php7-gd php7-cli runit parallel ssmtp \
-                        libltdl libintl openssl-dev php7-apache2 procps tzdata \
+                        php8 php8-gd php8-cli runit parallel ssmtp \
+                        libltdl libintl openssl-dev php8-apache2 procps tzdata \
                         libldap mariadb-connector-c freeradius-client-dev libpq libdbi \
                         lm-sensors perl net-snmp-perl perl-net-snmp perl-crypt-x509 \
                         perl-timedate perl-libwww perl-text-glob samba-client openssh openssl \


### PR DESCRIPTION
Updated image to use Alpine v3.16 & PHP8.

Interesting outcome is that the v3.16/php8 image is 12MB smaller than the previous v3.12/php7:

nagios-alpine312  latest       283177380089   4 minutes ago    216MB
nagios-alpine316  latest       a48db1ef3aaf   17 minutes ago   204MB
